### PR TITLE
Feat: engine may join existing session

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(tashi_vertex_rs)
 include(FetchContent)
 
 # Set the GitHub archive URL and version
-set(TASHI_VERTEX_VERSION "0.12.0")
+set(TASHI_VERTEX_VERSION "0.13.0")
 set(TASHI_VERTEX_URL "https://github.com/tashigg/tashi-vertex-c/releases/download/v${TASHI_VERTEX_VERSION}/tashi-vertex-${TASHI_VERTEX_VERSION}.zip")
 
 # Download and extract the pre-built library

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "tashi-vertex"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tashi-vertex"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -64,10 +64,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Initialize the runtime and bind a socket
     let context = Context::new()?;
     let socket = Socket::bind(&context, "127.0.0.1:9000").await?;
+    let joining_running_session = false; // new session
 
     // Start the consensus engine
     let options = Options::default();
-    let engine = Engine::start(&context, socket, options, &key, peers)?;
+    let engine = Engine::start(&context, socket, options, &key, peers, joining_running_session)?;
 
     // Send a transaction
     let data = b"hello world";

--- a/examples/pingback.rs
+++ b/examples/pingback.rs
@@ -75,7 +75,7 @@ async fn main() -> anyhow::Result<()> {
 
     // start the engine
     // and begin participating in the network
-    let engine = Engine::start(&context, socket, options, &key, peers)?;
+    let engine = Engine::start(&context, socket, options, &key, peers, false)?;
 
     println!(" :: Started the consensus engine");
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -23,6 +23,7 @@ impl Engine {
         options: Options,
         secret: &KeySecret,
         peers: Peers,
+        joining_running_session: bool,
     ) -> crate::Result<Self> {
         let mut socket_ptr = socket.handle.as_ptr();
         let mut options_ptr = options.handle.as_ptr();
@@ -43,6 +44,7 @@ impl Engine {
                 secret,
                 &mut peers_ptr,
                 handle.as_mut_ptr(),
+                joining_running_session
             )
         }
         .ok()?;
@@ -73,5 +75,6 @@ unsafe extern "C" {
         secret: *const KeySecret,
         peers: *mut *mut TVPeers,
         engine: *mut Pointer<TVEngine>,
+        joining_running_session: bool
     ) -> TVResult;
 }


### PR DESCRIPTION
1. Allow nodes to join existing session during engine start.
2. Download binary version 0.13.0 during build.
