### PR TITLE
fix: prevent use-after-free in async Future callbacks (message.rs, socket.rs)

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -1,6 +1,7 @@
 use std::ffi::c_int;
 use std::os::raw::c_void;
 use std::pin::Pin;
+use std::sync::{Arc, Mutex};
 use std::task;
 
 use crate::engine::TVEngine;
@@ -25,17 +26,29 @@ impl Message {
         MessageRecieve {
             engine,
             invoked: false,
-            waker: None,
-            result: None,
+            // Shared state survives even if the Future is dropped while
+            // the C callback is still pending. This prevents use-after-free
+            // when tokio::select! drops this future.
+            shared: Arc::new(Mutex::new(SharedState {
+                waker: None,
+                result: None,
+            })),
         }
     }
+}
+
+/// State shared between the Future and the C callback via Arc.
+/// This ensures the callback always writes to valid memory, even
+/// if the Future has been dropped (e.g. by tokio::select!).
+struct SharedState {
+    waker: Option<task::Waker>,
+    result: Option<crate::Result<Option<Message>>>,
 }
 
 struct MessageRecieve<'e> {
     engine: &'e Engine,
     invoked: bool,
-    waker: Option<task::Waker>,
-    result: Option<crate::Result<Option<Message>>>,
+    shared: Arc<Mutex<SharedState>>,
 }
 
 impl Future for MessageRecieve<'_> {
@@ -48,52 +61,70 @@ impl Future for MessageRecieve<'_> {
             data: *const c_void,
             user_data: *mut c_void,
         ) {
-            let user_data = unsafe { &mut *(user_data as *mut MessageRecieve) };
+            // user_data points to a leaked Arc<Mutex<SharedState>>.
+            // We reconstruct it here to write the result and wake the task.
+            let shared = unsafe { Arc::from_raw(user_data as *const Mutex<SharedState>) };
 
-            user_data.result = Some(match result.ok_with(message) {
+            let msg_result = match result.ok_with(message) {
                 Ok(MESSAGE_EVENT) => {
                     let handle = unsafe { Pointer::from_ptr_unchecked(data as *mut _) };
                     let event = Event { handle };
-
                     Ok(Some(Message::Event(event)))
                 }
 
                 Ok(MESSAGE_SYNC_POINT) => {
                     let handle = unsafe { Pointer::from_ptr_unchecked(data as *mut _) };
                     let sync_point = SyncPoint { handle };
-
                     Ok(Some(Message::SyncPoint(sync_point)))
                 }
 
                 Ok(_) => Ok(None),
                 Err(error) => Err(error),
-            });
+            };
 
-            if let Some(waker) = user_data.waker.take() {
+            let mut state = shared.lock().unwrap();
+            state.result = Some(msg_result);
+            if let Some(waker) = state.waker.take() {
                 waker.wake();
             }
+            // shared is dropped here, decrementing the Arc refcount.
+            // If the Future was already dropped, this is the last reference
+            // and the SharedState is freed safely.
         }
 
         if !self.invoked {
-            // this is the first time poll is called
-            // invoke the bind operation
-
-            self.waker = Some(cx.waker().clone());
+            // First poll: register the waker and invoke the C recv
+            {
+                let mut state = self.shared.lock().unwrap();
+                state.waker = Some(cx.waker().clone());
+            }
             self.invoked = true;
+
+            // Leak an Arc clone so the C callback owns a reference.
+            // This keeps SharedState alive even if the Future is dropped.
+            let shared_ptr = Arc::into_raw(Arc::clone(&self.shared));
 
             let res = unsafe {
                 tv_message_recv(
                     self.engine.handle.as_ptr(),
                     callback,
-                    self.get_mut() as *mut _ as *mut c_void,
+                    shared_ptr as *mut c_void,
                 )
             };
 
             if let Err(error) = res.ok() {
+                // Reclaim the leaked Arc since callback won't fire
+                unsafe { Arc::from_raw(shared_ptr) };
                 return task::Poll::Ready(Err(error));
             }
-        } else if let Some(result) = self.result.take() {
-            return task::Poll::Ready(result);
+        } else {
+            // Subsequent polls: check if the callback has delivered a result
+            let mut state = self.shared.lock().unwrap();
+            if let Some(result) = state.result.take() {
+                return task::Poll::Ready(result);
+            }
+            // Update the waker in case tokio moved us to a different worker
+            state.waker = Some(cx.waker().clone());
         }
 
         task::Poll::Pending

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -1,6 +1,7 @@
 use std::ffi::{CString, c_char};
 use std::os::raw::c_void;
 use std::pin::Pin;
+use std::sync::{Arc, Mutex};
 use std::task;
 
 use crate::Context;
@@ -27,18 +28,27 @@ impl Socket {
             context,
             address,
             invoked: false,
-            waker: None,
-            result: None,
+            shared: Arc::new(Mutex::new(SharedBindState {
+                waker: None,
+                result: None,
+            })),
         }
     }
+}
+
+/// State shared between the Future and the C callback via Arc.
+/// Ensures the callback always writes to valid memory even if the
+/// Future is dropped (e.g. by tokio::select! or timeout).
+struct SharedBindState {
+    waker: Option<task::Waker>,
+    result: Option<crate::Result<Socket>>,
 }
 
 struct SocketBind<'a> {
     context: &'a Context,
     address: CString,
     invoked: bool,
-    waker: Option<task::Waker>,
-    result: Option<crate::Result<Socket>>,
+    shared: Arc<Mutex<SharedBindState>>,
 }
 
 impl Future for SocketBind<'_> {
@@ -50,36 +60,45 @@ impl Future for SocketBind<'_> {
             socket: Pointer<TVSocket>,
             user_data: *mut c_void,
         ) {
-            let user_data = unsafe { &mut *(user_data as *mut SocketBind) };
+            let shared = unsafe { Arc::from_raw(user_data as *const Mutex<SharedBindState>) };
 
-            user_data.result = Some(result.ok_with(socket).map(|handle| Socket { handle }));
+            let bind_result = result.ok_with(socket).map(|handle| Socket { handle });
 
-            if let Some(waker) = user_data.waker.take() {
+            let mut state = shared.lock().unwrap();
+            state.result = Some(bind_result);
+            if let Some(waker) = state.waker.take() {
                 waker.wake();
             }
         }
 
         if !self.invoked {
-            // this is the first time poll is called
-            // invoke the bind operation
-
-            self.waker = Some(cx.waker().clone());
+            {
+                let mut state = self.shared.lock().unwrap();
+                state.waker = Some(cx.waker().clone());
+            }
             self.invoked = true;
+
+            let shared_ptr = Arc::into_raw(Arc::clone(&self.shared));
 
             let res = unsafe {
                 tv_socket_bind(
                     self.context.handle.as_ptr(),
                     self.address.as_ptr(),
                     callback,
-                    self.get_mut() as *mut _ as *mut c_void,
+                    shared_ptr as *mut c_void,
                 )
             };
 
             if let Err(error) = res.ok() {
+                unsafe { Arc::from_raw(shared_ptr) };
                 return task::Poll::Ready(Err(error));
             }
-        } else if let Some(result) = self.result.take() {
-            return task::Poll::Ready(result);
+        } else {
+            let mut state = self.shared.lock().unwrap();
+            if let Some(result) = state.result.take() {
+                return task::Poll::Ready(result);
+            }
+            state.waker = Some(cx.waker().clone());
         }
 
         task::Poll::Pending


### PR DESCRIPTION
## Problem

Both `MessageRecieve` (message.rs) and `SocketBind` (socket.rs) pass a raw pointer to `self` as `user_data` into C callbacks (`tv_message_recv`, `tv_socket_bind`). When the Future is dropped before the callback fires — which happens routinely with `tokio::select!` — the callback writes to freed memory and calls `waker.wake()` on a dangling waker.

This triggers a panic in tokio's task state machine:

```
thread 'tokio-runtime-worker' panicked at
  tokio/src/runtime/task/state.rs:456:
  assertion failed: curr.is_join_waker_set()
```

### Reproduction

Any application using `tokio::select!` with `engine.recv_message()` alongside other async branches (timers, channels) will eventually hit this panic. It occurs when the select! macro drops the recv_message future because another branch completed first.

Minimal example:
```rust
loop {
    tokio::select! {
        msg = engine.recv_message() => { /* process */ }
        _ = heartbeat_interval.tick() => { /* send heartbeat */ }
    }
}
```

## Fix

Replace the raw `self` pointer with `Arc<Mutex<SharedState>>`. The callback receives a leaked `Arc` clone via `Arc::into_raw()`, which keeps the shared state alive even after the Future is dropped. When the callback fires:

1. Reconstructs the Arc with `Arc::from_raw()`
2. Writes the result to shared state
3. Wakes the task (if still alive)
4. Drops its reference — if the Future was already dropped, this is the last reference and cleanup is safe

This is the standard pattern for bridging C callbacks with Rust async Futures.

## Changes

- `message.rs`: `MessageRecieve` now uses `Arc<Mutex<SharedState>>` instead of raw `self` pointer
- `socket.rs`: `SocketBind` uses the same pattern for consistency

## Testing

Tested in a 5-node Vertex swarm (Hive Inference hackathon project) with frequent `tokio::select!` cancellation of `recv_message()` — zero panics across 100+ consensus rounds, compared to consistent panics before the fix.