### PR TITLE
Update bindings to tashi-vertex v0.14.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,44 +3,73 @@ project(tashi_vertex_rs)
 
 include(FetchContent)
 
-# Set the GitHub archive URL and version
 set(TASHI_VERTEX_VERSION "0.13.0")
 set(TASHI_VERTEX_URL "https://github.com/tashigg/tashi-vertex-c/releases/download/v${TASHI_VERTEX_VERSION}/tashi-vertex-${TASHI_VERTEX_VERSION}.zip")
 
-# Download and extract the pre-built library
-FetchContent_Declare(
-    TASHI_VERTEX
-    URL ${TASHI_VERTEX_URL}
-    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
-)
-
-FetchContent_MakeAvailable(TASHI_VERTEX)
-
-# Set library paths based on the extracted content
-set(TASHI_VERTEX_LIB_DIR "${tashi_vertex_SOURCE_DIR}/lib")
-
-# Create an imported library target
-add_library(TASHI_VERTEX SHARED IMPORTED GLOBAL)
-
-# Set the library file location (adjust extension based on platform)
-if(WIN32)
-    set(TASHI_VERTEX_LIB_FILE "${TASHI_VERTEX_LIB_DIR}/tashi-vertex.dll")
-    set_target_properties(TASHI_VERTEX PROPERTIES
-        IMPORTED_LOCATION "${TASHI_VERTEX_LIB_FILE}"
-    )
-elseif(APPLE)
-    set(TASHI_VERTEX_LIB_FILE "${TASHI_VERTEX_LIB_DIR}/libtashi-vertex.dylib")
-    set_target_properties(TASHI_VERTEX PROPERTIES
-        IMPORTED_LOCATION "${TASHI_VERTEX_LIB_FILE}"
-    )
+# Local-build switch. Enable via `-DTASHI_VERTEX_LOCAL_BUILD=ON` or by exporting
+# `TASHI_VERTEX_LOCAL_BUILD=1` before invoking cargo. When on, the build skips
+if(DEFINED ENV{TASHI_VERTEX_LOCAL_BUILD} AND NOT "$ENV{TASHI_VERTEX_LOCAL_BUILD}" STREQUAL "")
+    set(_tashi_vertex_local_default "$ENV{TASHI_VERTEX_LOCAL_BUILD}")
 else()
-    set(TASHI_VERTEX_LIB_FILE "${TASHI_VERTEX_LIB_DIR}/libtashi-vertex.so")
-    set_target_properties(TASHI_VERTEX PROPERTIES
-        IMPORTED_LOCATION "${TASHI_VERTEX_LIB_FILE}"
-    )
+    set(_tashi_vertex_local_default OFF)
+endif()
+option(TASHI_VERTEX_LOCAL_BUILD "Link against a locally-built tashi-vertex instead of downloading a release" ${_tashi_vertex_local_default})
+
+set(_tashi_vertex_local_dir_default "${CMAKE_CURRENT_SOURCE_DIR}/../tashi-vertex-c")
+if(DEFINED ENV{TASHI_VERTEX_LOCAL_DIR} AND NOT "$ENV{TASHI_VERTEX_LOCAL_DIR}" STREQUAL "")
+    set(_tashi_vertex_local_dir_default "$ENV{TASHI_VERTEX_LOCAL_DIR}")
+endif()
+set(TASHI_VERTEX_LOCAL_DIR "${_tashi_vertex_local_dir_default}" CACHE PATH "Path to the local tashi-vertex-c checkout (containing lib/ and include/)")
+
+if(WIN32)
+    set(TASHI_VERTEX_ARCHIVE_LIB "tashi-vertex.dll")
+    set(TASHI_VERTEX_INSTALLED_LIB "tashi-vertex.dll")
+elseif(APPLE)
+    set(TASHI_VERTEX_ARCHIVE_LIB "libtashi-vertex.dylib")
+    set(TASHI_VERTEX_INSTALLED_LIB "libtashi-vertex.dylib")
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64)$")
+        set(TASHI_VERTEX_ARCHIVE_LIB "libtashi-vertex-arm64.so")
+    elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^riscv64")
+        set(TASHI_VERTEX_ARCHIVE_LIB "libtashi-vertex-riscv64.so")
+    elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|amd64|AMD64)$")
+        set(TASHI_VERTEX_ARCHIVE_LIB "libtashi-vertex.so")
+    else()
+        message(FATAL_ERROR "Tashi Vertex: unsupported Linux architecture '${CMAKE_SYSTEM_PROCESSOR}'")
+    endif()
+    set(TASHI_VERTEX_INSTALLED_LIB "libtashi-vertex.so")
+else()
+    message(FATAL_ERROR "Tashi Vertex: unsupported platform '${CMAKE_SYSTEM_NAME}'")
 endif()
 
-# Install the library
-install(FILES ${TASHI_VERTEX_LIB_FILE}
+if(TASHI_VERTEX_LOCAL_BUILD)
+    set(TASHI_VERTEX_LIB_DIR "${TASHI_VERTEX_LOCAL_DIR}/lib")
+    message(STATUS "Tashi Vertex: using local build from ${TASHI_VERTEX_LIB_DIR}")
+    if(NOT EXISTS "${TASHI_VERTEX_LIB_DIR}/${TASHI_VERTEX_ARCHIVE_LIB}")
+        message(FATAL_ERROR
+            "Tashi Vertex: local library '${TASHI_VERTEX_ARCHIVE_LIB}' not found in "
+            "'${TASHI_VERTEX_LIB_DIR}'. Run the tashi-vertex build script first, or "
+            "set TASHI_VERTEX_LOCAL_DIR to the correct path.")
+    endif()
+else()
+    message(STATUS "Tashi Vertex: fetching ${TASHI_VERTEX_URL}")
+    FetchContent_Declare(
+        TASHI_VERTEX
+        URL ${TASHI_VERTEX_URL}
+        DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+    )
+    FetchContent_MakeAvailable(TASHI_VERTEX)
+    set(TASHI_VERTEX_LIB_DIR "${tashi_vertex_SOURCE_DIR}/lib")
+endif()
+
+set(TASHI_VERTEX_LIB_FILE "${TASHI_VERTEX_LIB_DIR}/${TASHI_VERTEX_ARCHIVE_LIB}")
+
+add_library(TASHI_VERTEX SHARED IMPORTED GLOBAL)
+set_target_properties(TASHI_VERTEX PROPERTIES
+    IMPORTED_LOCATION "${TASHI_VERTEX_LIB_FILE}"
+)
+
+install(FILES "${TASHI_VERTEX_LIB_FILE}"
     DESTINATION lib
+    RENAME "${TASHI_VERTEX_INSTALLED_LIB}"
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(tashi_vertex_rs)
 include(FetchContent)
 
 set(TASHI_VERTEX_VERSION "0.14.0")
-set(TASHI_VERTEX_URL "https://github.com/tashigg/tashi-vertex-c/releases/download/v${TASHI_VERTEX_VERSION}/tashi-vertex-${TASHI_VERTEX_VERSION}.zip")
+set(TASHI_VERTEX_URL "https://github.com/tashigit/tashi-vertex-c/releases/download/v${TASHI_VERTEX_VERSION}/tashi-vertex-${TASHI_VERTEX_VERSION}.zip")
 
 # Local-build switch. Enable via `-DTASHI_VERTEX_LOCAL_BUILD=ON` or by exporting
 # `TASHI_VERTEX_LOCAL_BUILD=1` before invoking cargo. When on, the build skips

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(tashi_vertex_rs)
 
 include(FetchContent)
 
-set(TASHI_VERTEX_VERSION "0.13.0")
+set(TASHI_VERTEX_VERSION "0.14.0")
 set(TASHI_VERTEX_URL "https://github.com/tashigg/tashi-vertex-c/releases/download/v${TASHI_VERTEX_VERSION}/tashi-vertex-${TASHI_VERTEX_VERSION}.zip")
 
 # Local-build switch. Enable via `-DTASHI_VERTEX_LOCAL_BUILD=ON` or by exporting

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "tashi-vertex"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "tashi-vertex"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 description = "Rust bindings for Tashi Vertex, an embedded BFT consensus engine based on Hashgraph."
 license = "Apache-2.0"
-repository = "https://github.com/tashigg/tashi-vertex-rs"
+repository = "https://github.com/tashigit/tashi-vertex-rs"
 readme = "README.md"
 keywords = ["consensus", "bft", "hashgraph", "tashi-vertex", "vertex"]
 categories = ["cryptography", "network-programming"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,6 +15,10 @@ pub(crate) enum TVResult {
     BufferTooSmall = -5,
     Base58Decode = -6,
     SocketBind = -7,
+    EngineStart = -8,
+    MessageReceive = -9,
+    TransactionSendClosed = -10,
+    TransactionDataTooLarge = -11,
 }
 
 impl TVResult {
@@ -35,6 +39,10 @@ impl TVResult {
             Self::BufferTooSmall => Err(Error::BufferTooSmall),
             Self::Base58Decode => Err(Error::Base58Decode),
             Self::SocketBind => Err(Error::SocketBind),
+            Self::EngineStart => Err(Error::EngineStart),
+            Self::MessageReceive => Err(Error::MessageReceive),
+            Self::TransactionSendClosed => Err(Error::TransactionSendClosed),
+            Self::TransactionDataTooLarge => Err(Error::TransactionDataTooLarge),
         }
     }
 
@@ -67,6 +75,18 @@ pub enum Error {
 
     /// Failed to bind a socket.
     SocketBind,
+
+    /// Failed to start the engine.
+    EngineStart,
+
+    /// General failure to receive a message. Likely the stream has been closed.
+    MessageReceive,
+
+    /// Attempt to send a transaction on a shutdown engine.
+    TransactionSendClosed,
+
+    /// The transaction data exceeds the maximum allowed size (512 MiB).
+    TransactionDataTooLarge,
 }
 
 impl StdError for Error {
@@ -79,6 +99,14 @@ impl StdError for Error {
             Self::BufferTooSmall => "A provided buffer was too small to hold the required data.",
             Self::Base58Decode => "Failed to decode a Base58 string.",
             Self::SocketBind => "Failed to bind a socket.",
+            Self::EngineStart => "Failed to start the engine.",
+            Self::MessageReceive => {
+                "General failure to receive a message. Likely the stream has been closed."
+            }
+            Self::TransactionSendClosed => "Attempt to send a transaction on a shutdown engine.",
+            Self::TransactionDataTooLarge => {
+                "The transaction data exceeds the maximum allowed size (512 MiB)."
+            }
         }
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -60,7 +60,6 @@ impl Event {
         unsafe {
             tv_event_get_whitened_signature(
                 self.handle.as_ptr(),
-                0,
                 &mut signature_ptr,
                 &mut signature_size,
             )
@@ -161,7 +160,6 @@ unsafe extern "C" {
 
     fn tv_event_get_whitened_signature(
         event: *const TVEvent,
-        index: usize,
         signature: *mut *mut u8,
         signature_size: *mut usize,
     ) -> TVResult;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ pub use key_public::KeyPublic;
 pub use key_secret::KeySecret;
 pub use message::Message;
 pub use options::Options;
-pub use peers::Peers;
+pub use peers::{PeerCapabilities, Peers};
 pub use socket::Socket;
 pub use sync_point::SyncPoint;
 pub use transaction::Transaction;

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,4 +1,7 @@
-use std::{ffi::c_void, mem::MaybeUninit};
+use std::{
+    ffi::{CString, c_char, c_void},
+    mem::MaybeUninit,
+};
 
 use crate::error::TVResult;
 use crate::ptr::Pointer;
@@ -201,6 +204,54 @@ impl Options {
         unsafe { tv_options_set_enable_hole_punching(self.handle.as_ptr(), enabled) }.assert_ok();
     }
 
+    /// Sets the directory the engine uses to persist consensus events.
+    ///
+    /// Pass `None` to clear the configured path (the engine reverts to
+    /// in-memory-only behaviour).
+    ///
+    /// Persistence requires the engine to have been built with the
+    /// `persistence-rocksdb` feature; without it, the path is recorded but a
+    /// warning is logged at engine start and persistence stays disabled.
+    ///
+    pub fn set_storage_path(&mut self, path: Option<&str>) -> crate::Result<()> {
+        match path {
+            Some(path) => {
+                let path = CString::new(path).map_err(|_| crate::Error::Argument)?;
+
+                unsafe { tv_options_set_storage_path(self.handle.as_ptr(), path.as_ptr()) }.ok()
+            }
+            None => {
+                unsafe { tv_options_set_storage_path(self.handle.as_ptr(), std::ptr::null()) }.ok()
+            }
+        }
+    }
+
+    /// Enables or disables strict (ECDSA) re-verification of persisted events
+    /// at engine startup.
+    ///
+    /// Defaults to `false`, which trusts that bytes-on-disk were already verified
+    /// before they were written. Flip on for paranoid builds where on-disk tampering
+    /// is in the threat model.
+    ///
+    pub fn set_strict_replay_verify(&mut self, enabled: bool) {
+        unsafe { tv_options_set_strict_replay_verify(self.handle.as_ptr(), enabled) }.assert_ok();
+    }
+
+    /// Makes the engine wait for `push_application_state_proof` calls instead
+    /// of auto-filling empty state proofs at each epoch transition.
+    ///
+    /// Defaults to `false` (auto-fill). Set to `true` only if your application
+    /// reliably supplies a state proof for every epoch — otherwise consensus
+    /// will deadlock at the next epoch boundary.
+    ///
+    /// This is independent of [`set_enable_state_sharing`](Self::set_enable_state_sharing):
+    /// the latter controls whether peers may request our state, this one controls
+    /// whether the engine itself produces empty state proofs to keep consensus moving.
+    ///
+    pub fn set_wait_for_state_report(&mut self, enabled: bool) {
+        unsafe { tv_options_set_wait_for_state_report(self.handle.as_ptr(), enabled) }.assert_ok();
+    }
+
     /// Gets the base minimum event interval (in microseconds).
     pub fn get_base_min_event_interval_us(&self) -> u64 {
         let mut interval = 0;
@@ -349,6 +400,62 @@ impl Options {
 
         enabled
     }
+
+    /// Gets the configured storage path, or `None` if no path is configured.
+    pub fn get_storage_path(&self) -> crate::Result<Option<String>> {
+        // First probe with no buffer to learn the required length.
+        let mut required: usize = 0;
+
+        unsafe {
+            tv_options_get_storage_path(self.handle.as_ptr(), std::ptr::null_mut(), 0, &mut required)
+        }
+        .ok()?;
+
+        if required == 0 {
+            return Ok(None);
+        }
+
+        // Allocate room for the path plus the trailing NUL, then read it.
+        let mut buf = vec![0u8; required + 1];
+        let mut out_len: usize = 0;
+
+        unsafe {
+            tv_options_get_storage_path(
+                self.handle.as_ptr(),
+                buf.as_mut_ptr() as *mut c_char,
+                buf.len(),
+                &mut out_len,
+            )
+        }
+        .ok()?;
+
+        buf.truncate(out_len);
+
+        String::from_utf8(buf)
+            .map(Some)
+            .map_err(|_| crate::Error::Argument)
+    }
+
+    /// Gets whether strict (ECDSA) re-verification of persisted events is enabled.
+    pub fn get_strict_replay_verify(&self) -> bool {
+        let mut enabled = false;
+
+        unsafe { tv_options_get_strict_replay_verify(self.handle.as_ptr(), &mut enabled) }
+            .assert_ok();
+
+        enabled
+    }
+
+    /// Gets whether the engine waits for state reports instead of auto-filling
+    /// empty state proofs at each epoch transition.
+    pub fn get_wait_for_state_report(&self) -> bool {
+        let mut enabled = false;
+
+        unsafe { tv_options_get_wait_for_state_report(self.handle.as_ptr(), &mut enabled) }
+            .assert_ok();
+
+        enabled
+    }
 }
 
 pub(crate) type TVOptions = c_void;
@@ -392,6 +499,12 @@ unsafe extern "C" {
     fn tv_options_set_epoch_states_to_cache(options: *mut TVOptions, epochs: u16) -> TVResult;
 
     fn tv_options_set_enable_hole_punching(options: *mut TVOptions, enabled: bool) -> TVResult;
+
+    fn tv_options_set_storage_path(options: *mut TVOptions, path: *const c_char) -> TVResult;
+
+    fn tv_options_set_strict_replay_verify(options: *mut TVOptions, enabled: bool) -> TVResult;
+
+    fn tv_options_set_wait_for_state_report(options: *mut TVOptions, enabled: bool) -> TVResult;
 
     fn tv_options_get_base_min_event_interval_us(
         options: *const TVOptions,
@@ -458,6 +571,23 @@ unsafe extern "C" {
     ) -> TVResult;
 
     fn tv_options_get_enable_hole_punching(
+        options: *const TVOptions,
+        enabled: *mut bool,
+    ) -> TVResult;
+
+    fn tv_options_get_storage_path(
+        options: *const TVOptions,
+        buf: *mut c_char,
+        buf_len: usize,
+        out_len: *mut usize,
+    ) -> TVResult;
+
+    fn tv_options_get_strict_replay_verify(
+        options: *const TVOptions,
+        enabled: *mut bool,
+    ) -> TVResult;
+
+    fn tv_options_get_wait_for_state_report(
         options: *const TVOptions,
         enabled: *mut bool,
     ) -> TVResult;


### PR DESCRIPTION
## Summary

Updates the Rust bindings to match `tashi-vertex-c` v0.14.0 (built from consensus engine v0.14.0), and includes the CMake fetch/local-build refactor.

## Changes

- **CMake fetch refactor** (`e89eb5d`): local-build switch (`TASHI_VERTEX_LOCAL_BUILD` / `TASHI_VERTEX_LOCAL_DIR`), per-platform/arch library resolution, and install rules.
- **v0.14.0 bindings** (`7c017d9`):
  - Bump package and CMake fetch version to `0.14.0`.
  - Add new `TVResult` error codes: `EngineStart`, `MessageReceive`, `TransactionSendClosed`, `TransactionDataTooLarge`.
  - Drop the removed `index` parameter from `tv_event_get_whitened_signature`.
  - Add options: `storage_path`, `strict_replay_verify`, `wait_for_state_report` (getters + setters).
  - Export `PeerCapabilities`.
- **URL fix** (`8799951`): correct the release download org to `tashigit`.

## Test plan

- `cargo build` against a local `tashi-vertex-c` checkout: clean.
- `cargo clippy --all-targets`: clean (one pre-existing, unrelated warning in `examples/pingback.rs`).
- `cargo test`: passes (no unit/doc tests defined yet).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration options for storage path, replay verification, and state reports.
  * Introduced local build support with platform/architecture-specific library handling.

* **Chores**
  * Updated tashi-vertex dependency to version 0.14.0.
  * Added error codes for engine start, message receive, and transaction-related failures.
  * Exported peer capabilities in public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->