### PR TITLE
Update bindings to tashi-vertex v0.15.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(tashi_vertex_rs)
 
 include(FetchContent)
 
-set(TASHI_VERTEX_VERSION "0.14.0")
+set(TASHI_VERTEX_VERSION "0.15.0")
 set(TASHI_VERTEX_URL "https://github.com/tashigit/tashi-vertex-c/releases/download/v${TASHI_VERTEX_VERSION}/tashi-vertex-${TASHI_VERTEX_VERSION}.zip")
 
 # Local-build switch. Enable via `-DTASHI_VERTEX_LOCAL_BUILD=ON` or by exporting

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "tashi-vertex"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tashi-vertex"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2024"
 description = "Rust bindings for Tashi Vertex, an embedded BFT consensus engine based on Hashgraph."
 license = "Apache-2.0"

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,14 +1,17 @@
+use std::ffi::{CString, c_char};
 use std::mem::{self, MaybeUninit};
 use std::os::raw::c_void;
+use std::time::Duration;
 
 use crate::context::TVContext;
 use crate::error::TVResult;
+use crate::key_public::KEY_PUBLIC_DER_LENGTH;
 use crate::message::Message;
 use crate::options::TVOptions;
 use crate::peers::TVPeers;
 use crate::ptr::Pointer;
 use crate::socket::TVSocket;
-use crate::{Context, KeySecret, Options, Peers, Socket, Transaction};
+use crate::{Context, KeyPublic, KeySecret, Options, PeerCapabilities, Peers, Socket, Transaction};
 
 /// Handle for the Tashi Vertex (TV) engine.
 pub struct Engine {
@@ -63,6 +66,71 @@ impl Engine {
     pub fn send_transaction(&self, transaction: Transaction) -> crate::Result<()> {
         transaction.send(self)
     }
+
+    /// Returns the public keys of the current active voting creators
+    /// (the live BFT quorum membership).
+    pub fn active_creators(&self) -> crate::Result<Vec<KeyPublic>> {
+        let mut capacity = 16;
+
+        loop {
+            let mut buffer = vec![0u8; capacity * KEY_PUBLIC_DER_LENGTH];
+            let mut count = 0;
+
+            unsafe {
+                tv_engine_get_active_creators(
+                    self.handle.as_ptr(),
+                    buffer.as_mut_ptr(),
+                    capacity,
+                    &mut count,
+                )
+            }
+            .ok()?;
+
+            // count is the total number of active creators; if it exceeds the
+            // capacity we passed, only the first `capacity` keys were written,
+            // so retry with a buffer large enough for all of them
+            if count <= capacity {
+                return buffer[..count * KEY_PUBLIC_DER_LENGTH]
+                    .chunks_exact(KEY_PUBLIC_DER_LENGTH)
+                    .map(KeyPublic::from_der)
+                    .collect();
+            }
+
+            capacity = count;
+        }
+    }
+
+    /// Votes to (re-)admit a creator into the active voting set.
+    ///
+    /// A node that was kicked is no longer an active creator; restarting it
+    /// with `joining_running_session` lets it sync but does not make it a voter
+    /// again. Re-admission requires a supermajority of the current voters to
+    /// call this for the creator being recovered.
+    ///
+    /// The address, public key, and capabilities must describe the creator
+    /// exactly as in [`Peers::insert`]. The vote stays active for `timeout`
+    /// waiting for the supermajority to gather.
+    pub fn vote_add_node(
+        &self,
+        address: &str,
+        public: &KeyPublic,
+        capabilities: PeerCapabilities,
+        timeout: Duration,
+    ) -> crate::Result<()> {
+        let address = CString::new(address).map_err(|_| crate::Error::Argument)?;
+
+        let res = unsafe {
+            tv_engine_vote_add_node(
+                self.handle.as_ptr(),
+                address.as_ptr(),
+                public,
+                capabilities.to_flags() as u8,
+                timeout.as_secs(),
+            )
+        };
+
+        res.ok()
+    }
 }
 
 pub(crate) type TVEngine = c_void;
@@ -76,5 +144,20 @@ unsafe extern "C" {
         peers: *mut *mut TVPeers,
         engine: *mut Pointer<TVEngine>,
         joining_running_session: bool
+    ) -> TVResult;
+
+    fn tv_engine_get_active_creators(
+        engine: *const TVEngine,
+        out_buf: *mut u8,
+        cap_count: usize,
+        out_count: *mut usize,
+    ) -> TVResult;
+
+    fn tv_engine_vote_add_node(
+        engine: *const TVEngine,
+        address: *const c_char,
+        public: &KeyPublic,
+        capabilities: u8,
+        timeout_secs: u64,
     ) -> TVResult;
 }

--- a/src/key_public.rs
+++ b/src/key_public.rs
@@ -6,7 +6,7 @@ use std::{
 
 use crate::{base58, error::TVResult};
 
-const KEY_PUBLIC_DER_LENGTH: usize = 91;
+pub(crate) const KEY_PUBLIC_DER_LENGTH: usize = 91;
 const KEY_PUBLIC_DER_BASE58_LENGTH: usize = base58::encode_length(KEY_PUBLIC_DER_LENGTH);
 
 /// A public key used for verifying signatures in Tashi Vertex.

--- a/src/peers.rs
+++ b/src/peers.rs
@@ -30,7 +30,7 @@ pub struct PeerCapabilities {
 }
 
 impl PeerCapabilities {
-    const fn to_flags(&self) -> c_int {
+    pub(crate) const fn to_flags(&self) -> c_int {
         let mut flags = 0;
 
         if self.no_order {


### PR DESCRIPTION
Bumps the fetched tashi-vertex-c release to v0.15.0 and binds the two functions added in this release.

- `Engine::active_creators()` wraps `tv_engine_get_active_creators`, returning the public keys of the current active voting creators. The engine reports the total count, so the buffer grows and the call retries when it exceeds the passed capacity.
- `Engine::vote_add_node()` wraps `tv_engine_vote_add_node`, voting to re-admit a kicked creator into the active voting set. It reuses `PeerCapabilities` from `Peers::insert`, narrowed to the `u8` the C API takes.

`tv_options_set_max_resident_bytes` is declared in the tashi-vertex-c headers but not exported by the v0.15.0 libraries, so it stays unbound until it ships in a release.

No existing function signatures changed between 0.14.0 and 0.15.0, so the rest of the binding surface is untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving the current active voting creators.
  * Added support for submitting node re-admission votes with configurable capabilities and timeouts.

* **Chores**
  * Updated the package and Vertex dependency to version 0.15.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->